### PR TITLE
Fix the wrong negation of the instanceof check

### DIFF
--- a/typeScriptCodeGenerator.js
+++ b/typeScriptCodeGenerator.js
@@ -546,7 +546,7 @@ class TypeScriptCodeGenerator {
             this.writeDoc(codeWriter, doc, options);
 
             // modifiers
-            if (!elem._parent instanceof type.UMLInterface) {
+            if (!(elem._parent instanceof type.UMLInterface)) {
                 var _modifiers = this.getModifiers(elem);
                 if (_modifiers.length > 0) {
                     terms.push(_modifiers.join(" "));
@@ -674,7 +674,7 @@ class TypeScriptCodeGenerator {
 
             // modifiers
             console.log('writemember', 'elem', elem, elem._parent instanceof type.UMLInterface);
-            if (!elem._parent instanceof type.UMLInterface) {
+            if (!(elem._parent instanceof type.UMLInterface)) {
                 var _modifiers = this.getModifiers(elem);
                 if (_modifiers.length > 0) {
                     terms.push(_modifiers.join(" "));
@@ -830,4 +830,3 @@ function generate(baseModel, basePath, options) {
 }
 
 exports.generate = generate;
-


### PR DESCRIPTION
`!elem._parent instanceof type.UMLInterface`
leads to negating the `elem._parent` and then doing the `instanceof` check, which will always result in `false`.

Always returning `false` will lead to `var _modifiers = this.getModifiers(elem);` to not be called, which finally leads to `_modifiers.includes("abstract")` to fail, because `_modifiers` is not set